### PR TITLE
chore: use npm prepublish hook instead of prepare hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "npm run clean && npm run build:commonjs && npm run rollup",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "rollup": "rollup -c",
-    "prepare": "node scripts/release.js",
+    "prepublish": "node scripts/release.js",
     "release": "semantic-release"
   },
   "repository": {


### PR DESCRIPTION
Because prepare hook run before the package is packed and published,
on local npm install without any arguments, and when installing git
dependencies, see https://docs.npmjs.com/misc/scripts.